### PR TITLE
fix: cache early return, schedule caching, null safety, drop ipykernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-    "ipykernel>=6.29.5",
     "numpy>=1.26,<2.3",
     "pandas>=2.3.1",
     "pyarrow>=21.0.0",

--- a/src/pynascar/config.py
+++ b/src/pynascar/config.py
@@ -34,7 +34,7 @@ def set_options(
     fmt = s.df_format if df_format is None else str(df_format).lower()
     if fmt not in ("csv", "parquet"):
         fmt = "parquet"
-        raise UserWarning("Format must be csv or parquet. This will default to 'parquet'.")
+        raise ValueError("Format must be csv or parquet. This will default to 'parquet'.")
 
     _settings = Settings(
         cache_enabled = s.cache_enabled if cache_enabled is None else cache_enabled,

--- a/src/pynascar/core/process_data.py
+++ b/src/pynascar/core/process_data.py
@@ -149,7 +149,7 @@ class NASCARDataProcessor:
             return pd.DataFrame()
         
         lap_times = []
-        for i in data['laps']:
+        for i in data.get('laps', []):
                 driver = i.get('FullName')
                 number = i.get('Number')
                 manufacturer = i.get('Manufacturer')
@@ -208,7 +208,7 @@ class NASCARDataProcessor:
             return pd.DataFrame()
 
         events = []
-        laps = data.get('laps')
+        laps = data.get('laps', {})
         for k,v in laps.items():
                 for j in v:
                     events.append({

--- a/src/pynascar/core/process_data.py
+++ b/src/pynascar/core/process_data.py
@@ -227,6 +227,8 @@ class NASCARDataProcessor:
     
     @staticmethod
     def process_driver_data(data: Dict[str, Any]) -> pd.DataFrame:
+        if not data:
+            return pd.DataFrame()
         drivers = data[0].get('drivers', [])
         driver_list = []
         for i in drivers:

--- a/src/pynascar/race.py
+++ b/src/pynascar/race.py
@@ -154,7 +154,9 @@ class Race:
     def _get_winner_name(self) -> str:
         """Get the name of the race winner."""
         if not self.results.results.empty:
-            return self.results.results[self.results.results['finishing_position'] == 1]['driver_name'].values[0]
+            winner_rows = self.results.results[self.results.results['finishing_position'] == 1]['driver_name'].values
+            if len(winner_rows) > 0:
+                return winner_rows[0]
         return ""
 
     def _process_weekend_run_results(self, run_data: Dict) -> None:
@@ -279,6 +281,8 @@ class Race:
             self.metadata.series_id,
             self.metadata.race_id,
         )
+        if not adv_driver_stats_data:
+            return
         self.driver_data.driver_stats_advanced = self.data_processor.process_adv_driver_data(adv_driver_stats_data)
 
         self.driver_data.driver_stats_advanced['driver_name'] = self.driver_data.driver_stats_advanced['driver_name'].map(normalize_name)

--- a/src/pynascar/race.py
+++ b/src/pynascar/race.py
@@ -95,7 +95,8 @@ class Race:
                 self.results.cautions = cached_cautions if cached_cautions is not None else pd.DataFrame()
                 self.results.lead_changes = cached_lead_changes if cached_lead_changes is not None else pd.DataFrame()
                 self.metadata.winner = self._get_winner_name()
-        
+                return
+
         print(f"Fetching Data for {self.metadata.year}-{self.metadata.series_id}-{self.metadata.race_id}")
         race_data = self.api.get_race_data(year = self.metadata.year, series_id = self.metadata.series_id,
                                            race_id=self.metadata.race_id, live=self.live)

--- a/src/pynascar/schedule.py
+++ b/src/pynascar/schedule.py
@@ -38,12 +38,20 @@ class Schedule:
                 return
 
         url = f"https://cf.nascar.com/cacher/{self.year}/race_list_basic.json"
-        response = requests.get(url)
+        try:
+            response = requests.get(url, timeout=15)
+        except requests.RequestException as e:
+            warnings.warn(f"Failed to fetch race list: {e}")
+            return
         if response.status_code == 200:
             print(f"Fetching data for Year:{self.year} Series:{self.series_id}")
             data = response.json()
             # Filter the races by series ID
-            race_list = data[f'series_{self.series_id}']
+            series_key = f'series_{self.series_id}'
+            if series_key not in data:
+                warnings.warn(f"Series {self.series_id} not found in schedule data for {self.year}")
+                return
+            race_list = data[series_key]
             self.races = [race for race in race_list if race['series_id'] == self.series_id]
             self.data = pd.DataFrame(self.races)
             if "race_date" in self.data.columns:

--- a/src/pynascar/schedule.py
+++ b/src/pynascar/schedule.py
@@ -3,6 +3,7 @@ import warnings
 import pandas as pd
 import requests
 from .caching import load_schedule, save_schedule
+from .config import get_settings
 from .definitions import tracks_map
 
 # endpoint for race list
@@ -18,13 +19,14 @@ class Schedule:
         
     '''
     
-    def __init__(self, year, series_id, use_cache=False):
+    def __init__(self, year, series_id, use_cache=None):
         self.year = year
         self.series_id = series_id
         self.races = []
         self.data = pd.DataFrame()
-        self.use_cache = use_cache
-        self.fetch_races()      
+        # If not explicitly set, inherit from global set_options(cache_enabled=...) setting
+        self.use_cache = use_cache if use_cache is not None else get_settings().cache_enabled
+        self.fetch_races()
 
     def fetch_races(self):
         """Fetch the race list for the specified year and series ID."""
@@ -48,7 +50,7 @@ class Schedule:
                 self.data["scheduled_at"] = pd.to_datetime(
                         self.data["race_date"], errors="coerce", utc=True
                     )
-            
+
             self.data["track_type"] = self.data["track_name"].map(tracks_map).fillna("unknown")
 
             if self.use_cache:


### PR DESCRIPTION
## Summary

This PR fixes several crashes and correctness bugs found during integration testing:

**Cache / null safety (original fixes)**
- `race.py _load_results`: add missing `return` after cache hit — prevented redundant API calls on every access
- `process_data.py process_driver_data`: null-check input before indexing — prevented crash when API returns nothing
- `schedule.py`: default `use_cache=None` so it inherits the global `set_options()` setting instead of always caching
- `pyproject.toml`: remove `ipykernel` from runtime dependencies (it's a dev/notebook tool)

**Additional bug fixes**
- `config.py set_options`: raise `ValueError` instead of `UserWarning` for invalid `df_format` — `raise UserWarning(...)` is a misuse of the exception hierarchy and produces confusing behavior
- `race.py _get_winner_name`: guard `.values[0]` with a length check — raises `IndexError` when no driver has `finishing_position == 1` (e.g. data gaps, mid-race snapshots)
- `race.py _fetch_adv_driver_stats`: null-check API response before passing to `process_adv_driver_data` — prevented `AttributeError: 'NoneType' object has no attribute 'get'`
- `process_data.py process_laps_data`: use `data.get('laps', [])` instead of `data['laps']` — avoided `KeyError` when key is missing
- `process_data.py process_event_notes_data`: use `data.get('laps', {})` instead of `data.get('laps')` — avoided `TypeError: 'NoneType' is not iterable` when key is absent
- `schedule.py fetch_races`: wrap `requests.get()` in `try/except RequestException` — surfaces network failures as warnings instead of uncaught exceptions
- `schedule.py fetch_races`: guard `data[f'series_{series_id}']` with key check — avoided `KeyError` on unexpected API response shapes

## Test plan
- [ ] `Race(year, series_id, race_id)` with a fully cached race loads from cache without printing "Fetching Data"
- [ ] `Race(year, series_id, race_id)` where API returns no advanced driver stats does not raise AttributeError
- [ ] `set_options(df_format="invalid")` raises `ValueError`
- [ ] `Schedule(year, series_id)` on a network timeout issues a warning and returns empty data instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)